### PR TITLE
Support 2.1.4 and 2.2.0 NCP tile

### DIFF
--- a/tasks/config-nsx-t/task.sh
+++ b/tasks/config-nsx-t/task.sh
@@ -153,7 +153,7 @@ if [[ "$PRODUCT_VERSION" =~ ^2.1.0 ]]; then
   return
 fi
 
-if [[ "$PRODUCT_VERSION" =~ ^2.1.3 ]]; then
+if [[ "$PRODUCT_VERSION" =~ ^2.1.3|^2.1.4|^2.2.0 ]]; then
   # Set .properties.overlay_tz
   # Set .properties.tier0_router
   # Set .properties.container_ip_blocks[index][name]


### PR DESCRIPTION
Probably a more elegant solution but this will unblock 2.1.4 and 2.2.0 tile installations